### PR TITLE
Navbar Hiding Heading Fixed

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -19,22 +19,37 @@ const Navbar = () => {
      }, [])
 
     return (
-        <nav className={`text-darkBlue flex justify-between p-4 border-2 border-b-white fixed w-full navbar ${colorChange ? 'bg-white' : 'bg-[#EFF6FF]'} `}>
-            <h1 className='name text-2xl'>Burhan Haroon</h1>
-            <nav className='hidden sm:flex gap-5 text-lg'>
-                <Link href='/'>Home</Link>
-                <Link href='https://dev.to/burhanharoon'>
-                    <a target="_blank"> Blogs</a>
-                </Link>
+      <nav
+        className={`text-darkBlue flex justify-between p-4 border-2 border-b-white sticky top-0 w-full navbar ${
+          colorChange ? 'bg-white' : 'bg-[#EFF6FF]'
+        } `}
+      >
+        <h1 className="name text-2xl">Burhan Haroon</h1>
+        <nav className="hidden sm:flex gap-5 text-lg">
+          <Link href="/">Home</Link>
+          <Link href="https://dev.to/burhanharoon">
+            <a target="_blank"> Blogs</a>
+          </Link>
 
-
-                <Link href="https://www.linkedin.com/in/burhandev" target="_blank">
-                <a target="_blank">Contact Me</a>
-                </Link>
-            </nav>
-            <svg className="block sm:hidden h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+          <Link href="https://www.linkedin.com/in/burhandev" target="_blank">
+            <a target="_blank">Contact Me</a>
+          </Link>
         </nav>
-    )
+        <svg
+          className="block sm:hidden h-6 w-6"
+          stroke="currentColor"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M4 6h16M4 12h16M4 18h16"
+          ></path>
+        </svg>
+      </nav>
+    );
 }
 
 export default Navbar


### PR DESCRIPTION
In the mobile layout, the current navbar implementation hides the title introduction. It was fixed by changing the "position: fixed" to "position: sticky"  in the navbar component