### PR TITLE
[BUG-FIX] : Footer sticks at bottom with flexbox and margin.

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -5,7 +5,7 @@ const Footer = () => {
   const linkClassName = 'text-gray-500 hover:text-blue-500'
 
   return (
-    <footer className='flex items-center justify-center w-full bg-[#EFF6FF]'>
+    <footer className='flex mt-auto items-center justify-center w-full bg-[#EFF6FF]'>
       <div className='max-w-[1400px] flex flex-col w-full'>
         <div className='px-6 py-10'>
           <div className='grid lg:grid-cols-4 md:grid-cols-2 sm:grid-cols-2 grid-cols-none gap-8 pt-6'>

--- a/components/Layout/index.jsx
+++ b/components/Layout/index.jsx
@@ -4,11 +4,11 @@ import React from 'react'
 
 const Layout = ({ children }) => {
   return (
-    <>
+    <div className='flex flex-col min-h-screen'>
       <Navbar />
       <main>{children}</main>
       <Footer />
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Description
Layout improved so that the footer always sticks at bottom of the page even if the page doesn't have any content.

## Screenshot
<img width="770" alt="Screen Shot 2022-10-27 at 19 01 26" src="https://user-images.githubusercontent.com/59108522/198295239-465c008c-7f36-4ad7-ba1b-c02bf0fc2991.png">
